### PR TITLE
Improve performance of SendMessageToClient() calls (#24)

### DIFF
--- a/src/OSC/OSCPacket.cs
+++ b/src/OSC/OSCPacket.cs
@@ -48,7 +48,7 @@ namespace UnityOSC
 			}
 			set
 			{
-				Trace.Assert(string.IsNullOrEmpty(_address) == false);
+				Trace.Assert(string.IsNullOrEmpty(value) == false);
 				_address = value;
 			}
 		}

--- a/src/OSCHandler.cs
+++ b/src/OSCHandler.cs
@@ -157,6 +157,9 @@ public class OSCHandler : MonoBehaviour
 	/// </param>
 	public void CreateClient(string clientId, IPAddress destination, int port)
 	{
+		if (_clients.ContainsKey(clientId)) {
+			return;
+		}
 		ClientLog clientitem = new ClientLog();
 		clientitem.client = new OSCClient(destination, port);
 		clientitem.log = new List<string>();


### PR DESCRIPTION
+The null/empty check for the set property checks the current value (which is always null). It should check the value to be assigned instead.
+This also reduces GC (89KB) and CPU (8%) (reported by Unity Profiler on i7-3770)  

I still have a lot of probably unnecessary GC and CPU usage in the Unity Profiler, but this PR eliminates the most influential hits on performance. 